### PR TITLE
Add ability to bypass certificate validation on HA Url

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ media_lights_sync:
 | `media_player`           | False    | string or list |                     | The entity_id(s) of the media player(s) to sync from<sup id="ha-url">[1](#ha-url-note)</sup>.                               |
 | `lights`                 | False    | list           |                     | The list of all the lights entity_id to sync to.                                                                            |
 | `ha_url`                 | True     | string         | `null`              | The URL to your Home Assistant. Examples: `https://my-ha.duckdns.org`, `http://192.168.1.123:8123`.                         |
+| `verify_cert`            | True     | bool           | `true`              | Set to `false` if you are using `https` on your `ha-url` but are unable to trust the certificate. Bypasses cert validation. |
 | `reset_lights_after`     | True     | bool           | `false`             | Reset lights to their initial state after turning off a `medial_player`. Will not reset lights if `false`.                  |
 | `quantization_method`    | True     | string         | `MedianCut`         | Supports `MedianCut`, `FastOctree`, `MaxCoverage` and `libimagequant`. More info [below](#selecting-a-quantization_method). |
 | `use_saturated_colors`   | True     | bool           | `false`             | Increase the saturation and brightness of the colors.                                                                       |

--- a/apps/media_lights_sync/media_lights_sync.py
+++ b/apps/media_lights_sync/media_lights_sync.py
@@ -3,6 +3,7 @@ import appdaemon.plugins.hass.hassapi as hass
 import sys
 import io
 import colorsys
+import ssl
 
 from threading import Thread
 from PIL import Image, features
@@ -21,6 +22,7 @@ class MediaLightsSync(hass.Hass):
         args = self.args
         self.lights = args["lights"]
         self.ha_url = args.get("ha_url", None)
+        self.verify_cert = args.get("verify_cert", True)
         self.condition = args.get("condition")
         self.transition = args.get("transition", None)
         self.reset_lights_after = args.get("reset_lights_after", False)
@@ -111,7 +113,8 @@ class MediaLightsSync(hass.Hass):
 
     def get_colors(self, url):
         """Get the palette of colors from url."""
-        fd = urlopen(url)
+        context = ssl.SSLContext() if not self.verify_cert else None
+        fd = urlopen(url, context=context)
         f = io.BytesIO(fd.read())
         im = Image.open(f)
         if im.mode == "RGBA" and self.quantization_method not in [None, Image.FASTOCTREE, Image.LIBIMAGEQUANT]:


### PR DESCRIPTION
I have a self-generated cert on my local HA instance which cannot be validated and results in an SSL issue. This adds a new param called `verify_cert`. It defaults to `True` when not specified in `apps.yaml`, but when set to `False`, it will skip validation of the SSL cert on the `ha_url` endpoint.