### PR TITLE
Add template condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ media_lights_sync:
 
 <b id="ha-url-note">[1](#ha-url)</b>: See `/developer-tools/state` in your Home Assistant instance. This app will listen to changes on `entity_picture_local` and/or `entity_picture` attributes of your `media_player` entities.
 
+### Using a more complex `condition`
+
+You can use a template condition to match more complex states:
+
+```yaml
+condition:
+  value_template: "{{ state_attr('media_player.tv', 'media_content_type') == 'movie' and is_state('sun.sun', 'below_horizon') }}"
+```
+
+The app will run if the condition returns `True`.
+
 ## Selecting a `quantization_method`
 
 There is four [quantization method](https://pillow.readthedocs.io/en/stable/reference/Image.html?highlight=getpalette#quantization-methods) available, which change the way the colors palette is extracted:

--- a/apps/media_lights_sync/media_lights_sync.py
+++ b/apps/media_lights_sync/media_lights_sync.py
@@ -79,7 +79,12 @@ class MediaLightsSync(hass.Hass):
 
     def can_change_colors(self):
         """Validate that light should be sync if a condition is set."""
-        return self.condition is None or self.get_state(self.condition["entity"]) == self.condition["state"]
+        if self.condition is None:
+            return True
+        elif "value_template" in self.condition:
+            return self.render_template(self.condition["value_template"]) == True
+        else:
+            return self.get_state(self.condition["entity"]) == self.condition["state"]
 
     def store_initial_lights_states(self):
         """Save the initial state of all lights if not already done."""

--- a/tests/media_lights_sync_test.py
+++ b/tests/media_lights_sync_test.py
@@ -307,6 +307,28 @@ class TestConditions:
         assert conditional_media_lights_sync.can_change_colors() == False
 
 
+class TestTemplateConditions:
+    template = "{{ 'test' != 123 and is_state('sun.sun', 'below_horizon') }}"
+
+    @pytest.fixture
+    def conditional_template_media_lights_sync(self, media_lights_sync, given_that, update_passed_args):
+        given_that.state_of('sun.sun').is_set_to('below_horizon')
+        with update_passed_args():
+            given_that.passed_arg('condition').is_set_to({"value_template": self.template})
+
+        # hass.render_template is not available in appdaemontestframework, so we mock it here.
+        media_lights_sync.render_template = lambda _template: 'test' != 123 and media_lights_sync.get_state('sun.sun') == 'below_horizon'
+        return media_lights_sync
+
+    def test_can_change_if_condition_is_met(self, given_that, conditional_template_media_lights_sync):
+        given_that.state_of('sun.sun').is_set_to('below_horizon')
+        assert conditional_template_media_lights_sync.can_change_colors() == True
+
+    def test_wont_change_if_condition_is_false(self, given_that, conditional_template_media_lights_sync):
+        given_that.state_of('sun.sun').is_set_to('above_horizon')
+        assert conditional_template_media_lights_sync.can_change_colors() == False
+
+
 class TestFormatUrl:
     relative_url = "/api/media_player_proxy/media_player.tv_test"
 


### PR DESCRIPTION
Fixes #44.
Fixes #57.

This PR add a new way to setup the condition to wether or not to sync the lights with this app.

Example:

```yaml
condition:
  value_template: "{{ state_attr('media_player.tv', 'media_content_type') == 'movie' and is_state('sun.sun', 'below_horizon') }}"
```
